### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/LCDKeypad/keywords.txt
+++ b/LCDKeypad/keywords.txt
@@ -14,8 +14,8 @@ LCDKeypad	KEYWORD1
 
 button	KEYWORD2
 buttonBlocking	KEYWORD2
-backlight KEYWORD2
-noBacklight KEYWORD2
+backlight	KEYWORD2
+noBacklight	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords